### PR TITLE
Adding url param, fallback text, and fixing error logging

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,8 @@ inputs:
   action:
     description: 'Name of action (optional, defaults to "Build")'
     default: 'Build'
+  url:
+    description: 'Process target URL (optional, defaults to repo url)'
   version:
     description: 'Build version (optional)'
   platform:

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,7 +21,7 @@ async function run (): Promise < void > {
     const success = core.getInput('status') === 'Success'
     const channel = core.getInput('channel')
     const name = core.getInput('name') || github.context.payload.repository?.full_name || ''
-    const url = github.context.payload.repository?.html_url || ''
+    const url = core.getInput('url') || github.context.payload.repository?.html_url || ''
     const action = core.getInput('action')
     const version = core.getInput('version')
     const platform = core.getInput('platform')

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -40,9 +40,9 @@ export default async function SendSlack (token: string, options: NotificationOpt
           }
         }
       ],
-      text: label,
       color: options.success ? '#008000' : '#FF0000'
-    }]
+    }],
+    text: label,
   }
 
   const request = await fetch('https://slack.com/api/chat.postMessage', {
@@ -59,6 +59,6 @@ export default async function SendSlack (token: string, options: NotificationOpt
   if (requestJson.ok) {
     return 'Slack Notification Successful'
   } else {
-    throw new Error(`Slack Notification Failed: ${requestJson}`)
+    throw new Error(`Slack Notification Failed: ${requestJson.error}`)
   }
 }

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -40,9 +40,9 @@ export default async function SendSlack (token: string, options: NotificationOpt
           }
         }
       ],
-      color: options.success ? '#008000' : '#FF0000'
+      color: options.success ? '#008000' : '#FF0000',
+      fallback: label,
     }],
-    text: label,
   }
 
   const request = await fetch('https://slack.com/api/chat.postMessage', {

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -40,6 +40,7 @@ export default async function SendSlack (token: string, options: NotificationOpt
           }
         }
       ],
+      text: label,
       color: options.success ? '#008000' : '#FF0000'
     }]
   }


### PR DESCRIPTION
Added a param for passing a URL for the message. I've found this useful for linking to the failing action or PR.

I have also added a fallback field to the attachment to support clients that can't render it, and have fixed the error logging (previously a failed message would log `##[error]Slack Notification Failed: [object Object]`).

I think it's maybe worth changing the default URL to be the action's url (`https://github.com/<user_name>/<repo>/actions/runs/<run_id>`) - what do you think?